### PR TITLE
Resolve Cross Compile Problems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ endif()
 
 # allow thread library to be used for linking
 set(THREADS_PREFER_PTHREAD_FLAG ON)
+set(THREADS_PTHREAD_ARG "0" CACHE STRING "Result from TRY_RUN" FORCE)
 find_package(Threads REQUIRED)
 
 add_compile_options("$<$<CONFIG:DEBUG>:${DEBUG_FLAGS}>")


### PR DESCRIPTION
If to use pthreads with a cross compiling toolchain the variable `THREADS_PTHREAD_ARG` has to be set properly. This adds the necessary line to enable cross compiling support with pthreads.