### PR TITLE
Allow external spdlog dep to be used

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,13 +25,12 @@ find_package(Threads REQUIRED)
 add_compile_options("$<$<CONFIG:DEBUG>:${DEBUG_FLAGS}>")
 include(CMakeToolsHelpers OPTIONAL)
 
-# allow usage of installed dependency
-find_package(spdlog ${SPDLOG_MIN_VERSION})
-
-if(spdlog_FOUND)
-  add_library(spdlog INTERFACE IMPORTED)
-else()
+if (EXISTS ${CMAKE_SOURCE_DIR}/deps/spdlog/CMakeLists.txt)
   add_subdirectory(deps/spdlog)
+else()
+  # allow usage of installed dependency
+  find_package(spdlog ${SPDLOG_MIN_VERSION} REQUIRED)
+  add_library(spdlog INTERFACE IMPORTED)
 endif()
 
 # spdlog_setup

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.3)
 
 # project variables
 project(spdlog_setup VERSION 0.3.0 LANGUAGES CXX)
+set(SPDLOG_MIN_VERSION "0.14.0")
 
 # general fixed compiler settings
 if(${MSVC})
@@ -24,7 +25,14 @@ find_package(Threads REQUIRED)
 add_compile_options("$<$<CONFIG:DEBUG>:${DEBUG_FLAGS}>")
 include(CMakeToolsHelpers OPTIONAL)
 
-add_subdirectory(deps/spdlog)
+# allow usage of installed dependency
+find_package(spdlog ${SPDLOG_MIN_VERSION})
+
+if(spdlog_FOUND)
+  add_library(spdlog INTERFACE IMPORTED)
+else()
+  add_subdirectory(deps/spdlog)
+endif()
 
 # spdlog_setup
 add_library(spdlog_setup INTERFACE)
@@ -96,4 +104,3 @@ if(SPDLOG_SETUP_INCLUDE_UNIT_TESTS)
         --coverage)
   endif()
 endif()
-


### PR DESCRIPTION
- The external `spdlog` should be installed normally via `cmake` from the origin repository, and must be from version 0.14.0 as stated in its `CMakeLists.txt`.