### PR TITLE
re-use global_pattern

### DIFF
--- a/include/spdlog_setup/details/conf_impl.h
+++ b/include/spdlog_setup/details/conf_impl.h
@@ -1110,7 +1110,7 @@ inline void setup_loggers_impl(
 
         const auto selected_pattern_opt = pattern_value_opt
                                               ? move(pattern_value_opt)
-                                              : move(global_pattern_opt);
+                                              : global_pattern_opt;
 
         try {
             if (selected_pattern_opt) {


### PR DESCRIPTION
Do not move global_pattern_opt to allow use for multiple sinks.