### PR TITLE
More compatibility updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.3)
 
 # project variables
 project(spdlog_setup VERSION 0.3.0 LANGUAGES CXX)
-set(SPDLOG_MIN_VERSION "0.14.0")
+set(SPDLOG_MIN_VERSION "1.0.0")
 
 # general fixed compiler settings
 if(${MSVC})

--- a/include/spdlog_setup/details/conf_impl.h
+++ b/include/spdlog_setup/details/conf_impl.h
@@ -132,6 +132,7 @@ static constexpr auto MAX_FILES = "max_files";
 static constexpr auto MAX_SIZE = "max_size";
 static constexpr auto NAME = "name";
 static constexpr auto PATTERN = "pattern";
+static constexpr auto ROTATE_ON_OPEN = "rotate_on_open";
 static constexpr auto ROTATION_HOUR = "rotation_hour";
 static constexpr auto ROTATION_MINUTE = "rotation_minute";
 static constexpr auto SINKS = "sinks";
@@ -697,6 +698,7 @@ auto rotating_file_sink_from_table(
     using names::BASE_FILENAME;
     using names::MAX_FILES;
     using names::MAX_SIZE;
+    using names::ROTATE_ON_OPEN;
 
     // fmt
     using fmt::format;
@@ -731,8 +733,13 @@ auto rotating_file_sink_from_table(
             "Missing '{}' field of u64 value for rotating_file_sink",
             MAX_FILES));
 
+    const auto rotate_on_open = value_from_table_or<bool>(
+        sink_table,
+        ROTATE_ON_OPEN,
+        false);
+
     return make_shared<RotatingFileSink>(
-        base_filename, max_filesize, max_files);
+        base_filename, max_filesize, max_files, rotate_on_open);
 }
 
 template <class DailyFileSink>
@@ -1053,6 +1060,11 @@ inline void setup_loggers_impl(
     // set up possibly the global pattern if present
     auto global_pattern_opt =
         value_from_table_opt<string>(config, GLOBAL_PATTERN);
+
+    if (global_pattern_opt)
+    {
+        spdlog::set_pattern(*global_pattern_opt);
+    }
 
     for (const auto &logger_table : *loggers) {
         const auto name = value_from_table<string>(


### PR DESCRIPTION
Thanks for fixing the problems with 1.y.z. Your changes were much better than mine!

In this PR I added a config setting for the rotate_on_open argument to the spdlog rotating file sink constructor with commit https://github.com/gabime/spdlog/commit/2463fe92bd98025e601e6f383cb4e9951c59315b
I also updated the version check in CMakeLists.txt from 0.14.0 to 1.0.0.

Finally I added a call to spdlog::set_pattern if global_pattern was set. (This is not really a compatibility change, but I think it is more correct to have this logic in that to leave it out.)

Thanks again for your help!