### PR TITLE
Use pre versioning

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 0.3.0-alpha.2.{build}
+version: 0.3.0-pre.{build}
 
 image:
   - Visual Studio 2015

--- a/include/spdlog_setup/conf.h
+++ b/include/spdlog_setup/conf.h
@@ -1,7 +1,7 @@
 /**
  * Implementation of public facing functions in spdlog_setup.
  * @author Chen Weiguang
- * @version 0.3.0-alpha.2
+ * @version 0.3.0-pre
  */
 
 #pragma once

--- a/include/spdlog_setup/details/conf_impl.h
+++ b/include/spdlog_setup/details/conf_impl.h
@@ -1,7 +1,7 @@
 /**
  * Implementation of non-public facing functions in spdlog_setup.
  * @author Chen Weiguang
- * @version 0.3.0-alpha.2
+ * @version 0.3.0-pre
  */
 
 #pragma once

--- a/include/spdlog_setup/details/setup_error.h
+++ b/include/spdlog_setup/details/setup_error.h
@@ -1,7 +1,7 @@
 /**
  * Implementation of setup_error in spdlog_setup.
  * @author Chen Weiguang
- * @version 0.3.0-alpha.2
+ * @version 0.3.0-pre
  */
 
 #pragma once

--- a/include/spdlog_setup/details/template_impl.h
+++ b/include/spdlog_setup/details/template_impl.h
@@ -1,7 +1,7 @@
 /**
  * Implementation of the mini template engine in spdlog_setup.
  * @author Chen Weiguang
- * @version 0.3.0-alpha.2
+ * @version 0.3.0-pre
  */
 
 #pragma once

--- a/src/unit_test/unit_test.cpp
+++ b/src/unit_test/unit_test.cpp
@@ -1,7 +1,7 @@
 /**
  * Unit tests implementation.
  * @author Chen Weiguang
- * @version 0.3.0-alpha.2
+ * @version 0.3.0-pre
  */
 
 #define CATCH_CONFIG_MAIN


### PR DESCRIPTION
Rather than fixing the `0.3.0-alpha` or `0.3.0-beta`, use `0.3.0-pre` to indicate the current version isn't `0.3.0` yet (and may have breaking API), but yet allow flexibility to tag the `alpha` or `beta` tags.