### PR TITLE
Add dist sink support

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,11 +160,12 @@ The header files should be installed in `build/install/include`.
 - `daily_file_sink_mt`
 - `null_sink_st`
 - `null_sink_mt`
+- `dist_sink_st`
+- `dist_sink_mt`
 - `syslog_sink` (only for Linux, `SPDLOG_ENABLE_SYSLOG` preprocessor definition
   must be defined before any `spdlog`/`spdlog_setup` header is included)
 
-Currently `ostream_sink` and `dist_sink` do not fit into the use case and are
-not supported.
+Currently `ostream_sink` does not fit into the use case and is not supported.
 
 For more information about how the above sinks work in `spdlog`, please refer to
 the original `spdlog` sinks wiki page at:

--- a/src/unit_test/loggers.cpp
+++ b/src/unit_test/loggers.cpp
@@ -127,7 +127,9 @@ TEST_CASE(
 }
 
 TEST_CASE("Parse logger with sink", "[parse_logger_with_sink]") {
-    auto sink = spdlog_setup::details::setup_sink(generate_stdout_sink_st());
+    std::vector<std::string> ref_sinks;
+    auto sink =
+        spdlog_setup::details::setup_sink(generate_stdout_sink_st(), ref_sinks);
     const auto sinks_map =
         std::unordered_map<std::string, std::shared_ptr<spdlog::sinks::sink>>{
             {TEST_SINK_NAME, std::move(sink)}};
@@ -145,7 +147,9 @@ TEST_CASE("Parse logger with sink", "[parse_logger_with_sink]") {
 
 TEST_CASE(
     "Parse logger with missing sink", "[parse_logger_with_missing_sink]") {
-    auto sink = spdlog_setup::details::setup_sink(generate_stdout_sink_st());
+    std::vector<std::string> ref_sinks;
+    auto sink =
+        spdlog_setup::details::setup_sink(generate_stdout_sink_st(), ref_sinks);
     const auto sinks_map =
         std::unordered_map<std::string, std::shared_ptr<spdlog::sinks::sink>>{
             {"xxx", std::move(sink)}};

--- a/src/unit_test/sinks.cpp
+++ b/src/unit_test/sinks.cpp
@@ -41,3 +41,35 @@ TEST_CASE("Parse stderr sink mt", "[parse_generate_stderr_sink_mt]") {
     REQUIRE(typeid(*sink) == typeid(const spdlog::sinks::stderr_sink_mt &));
     REQUIRE(ref_sinks.empty());
 }
+
+TEST_CASE("Parse dist sink st", "[parse_generate_dist_sink_st]") {
+    std::vector<std::string> ref_sinks;
+    const auto sink =
+        spdlog_setup::details::setup_sink(generate_dist_sink_st(), ref_sinks);
+    REQUIRE(typeid(*sink) == typeid(const spdlog::sinks::dist_sink_st &));
+    REQUIRE_THAT(ref_sinks, Catch::Equals<std::string>({"sink1", "sink2"}));
+}
+
+TEST_CASE("Parse dist sink mt", "[parse_generate_dist_sink_mt]") {
+    std::vector<std::string> ref_sinks;
+    const auto sink =
+        spdlog_setup::details::setup_sink(generate_dist_sink_mt(), ref_sinks);
+    REQUIRE(typeid(*sink) == typeid(const spdlog::sinks::dist_sink_mt &));
+    REQUIRE_THAT(ref_sinks, Catch::Equals<std::string>({"sink1", "sink2"}));
+}
+
+TEST_CASE("Parse dist sink circular", "[parse_generate_dist_sink_circular]") {
+    REQUIRE_THROWS_AS(
+        spdlog_setup::details::setup_sinks(generate_dist_sink_circular()),
+        spdlog_setup::setup_error);
+}
+
+TEST_CASE("Parse dist ref sinks", "[parse_generate_dist_sink_refs]") {
+    auto sinks_map =
+        spdlog_setup::details::setup_sinks(generate_dist_sink_with_refs());
+    auto sink = sinks_map["dist_sink"];
+    REQUIRE(typeid(*sink) == typeid(const spdlog::sinks::dist_sink_mt &));
+    // Can't check the dist sink's wiring because there's no getter for its
+    // subordinate sinks, but setup_sinks returning normally rather than
+    // exceptionally is enough
+}

--- a/src/unit_test/sinks.cpp
+++ b/src/unit_test/sinks.cpp
@@ -11,25 +11,33 @@
 #include <typeinfo>
 
 TEST_CASE("Parse stdout sink st", "[parse_generate_stdout_sink_st]") {
+    std::vector<std::string> ref_sinks;
     const auto sink =
-        spdlog_setup::details::setup_sink(generate_stdout_sink_st());
+        spdlog_setup::details::setup_sink(generate_stdout_sink_st(), ref_sinks);
     REQUIRE(typeid(*sink) == typeid(const spdlog::sinks::stdout_sink_st &));
+    REQUIRE(ref_sinks.empty());
 }
 
 TEST_CASE("Parse stderr sink st", "[parse_generate_stderr_sink_st]") {
+    std::vector<std::string> ref_sinks;
     const auto sink =
-        spdlog_setup::details::setup_sink(generate_stderr_sink_st());
+        spdlog_setup::details::setup_sink(generate_stderr_sink_st(), ref_sinks);
     REQUIRE(typeid(*sink) == typeid(const spdlog::sinks::stderr_sink_st &));
+    REQUIRE(ref_sinks.empty());
 }
 
 TEST_CASE("Parse stdout sink mt", "[parse_generate_stdout_sink_mt]") {
+    std::vector<std::string> ref_sinks;
     const auto sink =
-        spdlog_setup::details::setup_sink(generate_stdout_sink_mt());
+        spdlog_setup::details::setup_sink(generate_stdout_sink_mt(), ref_sinks);
     REQUIRE(typeid(*sink) == typeid(const spdlog::sinks::stdout_sink_mt &));
+    REQUIRE(ref_sinks.empty());
 }
 
 TEST_CASE("Parse stderr sink mt", "[parse_generate_stderr_sink_mt]") {
+    std::vector<std::string> ref_sinks;
     const auto sink =
-        spdlog_setup::details::setup_sink(generate_stderr_sink_mt());
+        spdlog_setup::details::setup_sink(generate_stderr_sink_mt(), ref_sinks);
     REQUIRE(typeid(*sink) == typeid(const spdlog::sinks::stderr_sink_mt &));
+    REQUIRE(ref_sinks.empty());
 }

--- a/src/unit_test/sinks.h
+++ b/src/unit_test/sinks.h
@@ -44,3 +44,80 @@ inline auto generate_stderr_sink_mt() -> std::shared_ptr<cpptoml::table> {
     sink_table->insert(names::TYPE, std::string("stderr_sink_mt"));
     return std::move(sink_table);
 }
+
+inline auto generate_dist_sink(std::string type)
+    -> std::shared_ptr<cpptoml::table> {
+    namespace names = spdlog_setup::details::names;
+
+    auto ref_sinks = cpptoml::make_array();
+    ref_sinks->push_back(std::string("sink1"));
+    ref_sinks->push_back(std::string("sink2"));
+
+    auto sink_table = cpptoml::make_table();
+    sink_table->insert(names::TYPE, std::move(type));
+    sink_table->insert(names::SINKS, ref_sinks);
+    return std::move(sink_table);
+}
+
+inline auto generate_dist_sink_st() -> std::shared_ptr<cpptoml::table> {
+    return generate_dist_sink("dist_sink_st");
+}
+
+inline auto generate_dist_sink_mt() -> std::shared_ptr<cpptoml::table> {
+    return generate_dist_sink("dist_sink_mt");
+}
+
+inline auto generate_dist_sink_circular() -> std::shared_ptr<cpptoml::table> {
+    namespace names = spdlog_setup::details::names;
+
+    auto dist_sink1 = cpptoml::make_table();
+    dist_sink1->insert(names::NAME, std::string("sink1"));
+    dist_sink1->insert(names::TYPE, std::string("dist_sink_st"));
+    auto dist_sink1_sinks = cpptoml::make_array();
+    dist_sink1_sinks->push_back(std::string("sink2"));
+    dist_sink1->insert(names::SINKS, dist_sink1_sinks);
+
+    auto dist_sink2 = cpptoml::make_table();
+    dist_sink2->insert(names::NAME, std::string("sink2"));
+    dist_sink2->insert(names::TYPE, std::string("dist_sink_mt"));
+    auto dist_sink2_sinks = cpptoml::make_array();
+    dist_sink2_sinks->push_back(std::string("sink1"));
+    dist_sink2->insert(names::SINKS, dist_sink2_sinks);
+
+    auto sink_table = cpptoml::make_table_array();
+    sink_table->push_back(dist_sink1);
+    sink_table->push_back(dist_sink2);
+
+    auto config = cpptoml::make_table();
+    config->insert(names::SINK_TABLE, sink_table);
+    return std::move(config);
+}
+
+inline auto generate_dist_sink_with_refs() -> std::shared_ptr<cpptoml::table> {
+    namespace names = spdlog_setup::details::names;
+
+    auto dist_sink = cpptoml::make_table();
+    dist_sink->insert(names::NAME, std::string("dist_sink"));
+    dist_sink->insert(names::TYPE, std::string("dist_sink_mt"));
+    auto ref_sinks = cpptoml::make_array();
+    ref_sinks->push_back(std::string("sink1"));
+    ref_sinks->push_back(std::string("sink2"));
+    dist_sink->insert(names::SINKS, ref_sinks);
+
+    auto sink1 = cpptoml::make_table();
+    sink1->insert(names::NAME, std::string("sink1"));
+    sink1->insert(names::TYPE, std::string("null_sink_mt"));
+
+    auto sink2 = cpptoml::make_table();
+    sink2->insert(names::NAME, std::string("sink2"));
+    sink2->insert(names::TYPE, std::string("null_sink_mt"));
+
+    auto sink_table = cpptoml::make_table_array();
+    sink_table->push_back(dist_sink);
+    sink_table->push_back(sink1);
+    sink_table->push_back(sink2);
+
+    auto config = cpptoml::make_table();
+    config->insert(names::SINK_TABLE, sink_table);
+    return std::move(config);
+}


### PR DESCRIPTION
Hi again!

I implemented support for dist sinks (including verification that no circular references are made), and we're already using them. Was wondering whether you'd be interested. I saw that they were documented as 'not part of the use case', but I figured they might be useful for others some time or other, for grouping/aggregation within the configuration file :)

I'm a bit dissatisfied with the two dynamic casts, but alas, there is no common base class for both template instantiations that would allow me to call the relevant API, and I didn't want to propagate 'redundant' information through parameters.