### PR TITLE
Optionally use external spdlog library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ if(SPDLOG_SETUP_CPPTOML_EXTERNAL)
   configure_file(cmake/cpptoml_config.h.in "${CMAKE_CURRENT_BINARY_DIR}/include/spdlog_setup/details/third_party/cpptoml.h" @ONLY)
 endif()
 
-option(SPDLOG_SETUP_SPDLOG_EXTERNAL "Use external spdlog library in" OFF)
+option(SPDLOG_SETUP_SPDLOG_EXTERNAL "Use external spdlog library" OFF)
 
 # allow thread library to be used for linking
 set(THREADS_PREFER_PTHREAD_FLAG ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,8 @@ if(SPDLOG_SETUP_CPPTOML_EXTERNAL)
   configure_file(cmake/cpptoml_config.h.in "${CMAKE_CURRENT_BINARY_DIR}/include/spdlog_setup/details/third_party/cpptoml.h" @ONLY)
 endif()
 
+option(SPDLOG_SETUP_SPDLOG_EXTERNAL "Use external spdlog library in" OFF)
+
 # allow thread library to be used for linking
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 set(THREADS_PTHREAD_ARG "0" CACHE STRING "Result from TRY_RUN" FORCE)
@@ -47,12 +49,14 @@ find_package(Threads REQUIRED)
 add_compile_options("$<$<CONFIG:DEBUG>:${DEBUG_FLAGS}>")
 include(CMakeToolsHelpers OPTIONAL)
 
+if (NOT SPDLOG_SETUP_SPDLOG_EXTERNAL)
 if (EXISTS ${CMAKE_SOURCE_DIR}/deps/spdlog/CMakeLists.txt)
   add_subdirectory(deps/spdlog)
 else()
   # allow usage of installed dependency
   find_package(spdlog ${SPDLOG_MIN_VERSION} REQUIRED)
   add_library(${PROJECT_NAME}_spdlog INTERFACE IMPORTED)
+endif()
 endif()
 
 if(SPDLOG_SETUP_CPPTOML_EXTERNAL)


### PR DESCRIPTION
As mentioned in #7, it would be nice to allow external dependencies to be used.
This helps e.g. if you already have spdlog as a dependency in your CMake build.
With this small change, it is possible to turn off auto-detecting spdlog.
Leaving the `target_link_libraries(spdlog_setup ...)` calls as they are, these then simply use an existing `spdlog` library.
You need to add that library somewhere else in your build, then.
In my case, I have a line like

```
add_subdirectory(libs/cmake/spdlog-1.3.1)
```

in my top-level `CMakeLists.txt`.