### PR TITLE
Avoid multiply defined symbols linker errors

### DIFF
--- a/include/spdlog_setup/details/conf_impl.h
+++ b/include/spdlog_setup/details/conf_impl.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#ifndef FMT_HEADER_ONLY
+#if !defined(SPDLOG_COMPILED_LIB) && !defined(FMT_HEADER_ONLY)
 #define FMT_HEADER_ONLY
 #endif
 


### PR DESCRIPTION
When using spdlog_setup with a compiled spdlog library.
Fixes https://github.com/guangie88/spdlog_setup/issues/74.