### PR TITLE
Dont look for spdlog if spdlog::spdlog is already defined

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,12 +47,14 @@ find_package(Threads REQUIRED)
 add_compile_options("$<$<CONFIG:DEBUG>:${DEBUG_FLAGS}>")
 include(CMakeToolsHelpers OPTIONAL)
 
-if (EXISTS ${CMAKE_SOURCE_DIR}/deps/spdlog/CMakeLists.txt)
-  add_subdirectory(deps/spdlog)
-else()
-  # allow usage of installed dependency
-  find_package(spdlog ${SPDLOG_MIN_VERSION} REQUIRED)
-  add_library(${PROJECT_NAME}_spdlog INTERFACE IMPORTED)
+if(NOT TARGET spdlog::spdlog)
+  if (EXISTS ${CMAKE_SOURCE_DIR}/deps/spdlog/CMakeLists.txt)
+    add_subdirectory(deps/spdlog)
+  else()
+    # allow usage of installed dependency
+    find_package(spdlog ${SPDLOG_MIN_VERSION} REQUIRED)
+    add_library(${PROJECT_NAME}_spdlog INTERFACE IMPORTED)
+  endif()
 endif()
 
 if(SPDLOG_SETUP_CPPTOML_EXTERNAL)


### PR DESCRIPTION
If a project fetches spdlog from sources, spdlog::spdlog target will be defined, but a call to find_package(spdlog REQUIRED) will fail. 

If that same project also fetches spdlog_setup from sources, it will fail, as spdlog_setup will do a call to find_package(spdlog REQUIRED) even though spdlog::spdlog already exists.

This patch adds a check before trying to look for spdlog. 