### PR TITLE
add missing limits for numeric_limits use

### DIFF
--- a/include/spdlog_setup/details/third_party/cpptoml.h
+++ b/include/spdlog_setup/details/third_party/cpptoml.h
@@ -21,6 +21,7 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+#include <limits>
 
 #if __cplusplus > 201103L
 #define CPPTOML_DEPRECATED(reason) [[deprecated(reason)]]


### PR DESCRIPTION
Some compilers error with missing `numeric_limits` if you don't explicitly include `limits`