### PR TITLE
add missing limits for numeric_limits use

### DIFF
--- a/include/spdlog_setup/details/third_party/cpptoml.h
+++ b/include/spdlog_setup/details/third_party/cpptoml.h
@@ -21,6 +21,7 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+#include <limits>
 
 #if __cplusplus > 201103L
 #define CPPTOML_DEPRECATED(reason) [[deprecated(reason)]]


### PR DESCRIPTION
Depending on the compiler `numeric_limits` may or may not be available. Including `limits` explicitly works for any compiler